### PR TITLE
fix home page title

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,7 +20,7 @@ export default function Home() {
     const {siteConfig} = useDocusaurusContext();
     return (
         <Layout
-            title={`Home | ${siteConfig.title}`}
+            title={`Home`}
             description="Explore our design system that all of our products and services are built with.">
             <HomepageHeader />
             <main>


### PR DESCRIPTION
Docusaurus automatically adds the page title to the end of the page title, so adding it manually results in the page title appending to the end twice.
![image](https://user-images.githubusercontent.com/40342475/147701244-6aed97a3-1bc0-4bcb-a9fe-3802f6b706ca.png)
